### PR TITLE
Add monthly email automation

### DIFF
--- a/.github/workflows/monthly_report.yml
+++ b/.github/workflows/monthly_report.yml
@@ -1,0 +1,23 @@
+name: Monthly Payroll Report
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+jobs:
+  send-report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install -r requirements.txt
+      - run: python send_monthly_reports.py
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+          GMAIL_USER: ${{ secrets.GMAIL_USER }}
+          GMAIL_PASSWORD: ${{ secrets.GMAIL_PASSWORD }}
+          EMPLOYER_EMAIL: ${{ secrets.EMPLOYER_EMAIL }}

--- a/README.md
+++ b/README.md
@@ -19,8 +19,14 @@
    streamlit run app.py
    ```
 
+4. For email reports the following environment variables are required:
+   - `GMAIL_USER` / `GMAIL_PASSWORD`
+   - `EMPLOYER_EMAIL` (address that receives the monthly summary)
+
 ## Features
 
 - Admin login (Supabase Auth)
 - Add/view employees (name, email, salary)
 - Auto-calculate EPF/ETF, net salary, employer cost
+- Monthly email of payslips and employer summary via `send_monthly_reports.py`
+- GitHub Actions workflow runs the summary automatically on the 1st of every month

--- a/send_monthly_reports.py
+++ b/send_monthly_reports.py
@@ -1,0 +1,80 @@
+import os
+from supabase import create_client
+import pandas as pd
+import smtplib
+from email.message import EmailMessage
+
+SUPABASE_URL = os.environ.get("SUPABASE_URL")
+SUPABASE_KEY = os.environ.get("SUPABASE_KEY")
+
+if not SUPABASE_URL or not SUPABASE_KEY:
+    raise SystemExit("Missing SUPABASE credentials")
+
+supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
+
+def fetch_employees():
+    res = supabase.table("employees").select("*").execute()
+    return res.data or []
+
+def calculate_contributions(salary):
+    epf_employee = round(salary * 0.08, 2)
+    epf_employer = round(salary * 0.12, 2)
+    etf = round(salary * 0.03, 2)
+    net_salary = round(salary - epf_employee, 2)
+    employer_cost = round(salary + epf_employer + etf, 2)
+    return epf_employee, epf_employer, etf, net_salary, employer_cost
+
+def send_email(to_address: str, subject: str, body: str) -> None:
+    gmail_user = os.environ.get("GMAIL_USER")
+    gmail_password = os.environ.get("GMAIL_PASSWORD")
+    if not gmail_user or not gmail_password:
+        raise SystemExit("Missing Gmail credentials")
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = gmail_user
+    msg["To"] = to_address
+    msg.set_content(body)
+    with smtplib.SMTP_SSL("smtp.gmail.com", 465) as server:
+        server.login(gmail_user, gmail_password)
+        server.send_message(msg)
+
+def main():
+    employer_email = os.environ.get("EMPLOYER_EMAIL")
+    employees = fetch_employees()
+    if not employees:
+        print("No employees found.")
+        return
+    df = pd.DataFrame(employees)
+    df["EPF"], df["Employer EPF"], df["ETF"], df["Net"], df["Cost"] = zip(
+        *df["salary"].apply(calculate_contributions)
+    )
+    # Send payslips to employees
+    for _, row in df.iterrows():
+        body = (
+            f"Hello {row['name']},\n\n"
+            f"Gross Salary: {row['salary']:.2f}\n"
+            f"EPF (Employee 8%): {row['EPF']:.2f}\n"
+            f"EPF (Employer 12%): {row['Employer EPF']:.2f}\n"
+            f"ETF (3%): {row['ETF']:.2f}\n"
+            f"Net Salary: {row['Net']:.2f}\n"
+        )
+        send_email(row["email"], "Monthly Payslip", body)
+    # Prepare employer summary
+    summary = df[["name", "salary", "EPF", "Employer EPF", "ETF", "Cost"]]
+    total_line = pd.DataFrame(
+        {
+            "name": ["Total"],
+            "salary": [summary["salary"].sum()],
+            "EPF": [summary["EPF"].sum()],
+            "Employer EPF": [summary["Employer EPF"].sum()],
+            "ETF": [summary["ETF"].sum()],
+            "Cost": [summary["Cost"].sum()],
+        }
+    )
+    summary = pd.concat([summary, total_line], ignore_index=True)
+    body = summary.to_string(index=False)
+    if employer_email:
+        send_email(employer_email, "Monthly Payroll Summary", body)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- send automatic payroll emails with `send_monthly_reports.py`
- document environment variables for email notifications
- schedule monthly summary with GitHub Actions

## Testing
- `python -m py_compile send_monthly_reports.py app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852f42ea000832fbd0b0f6925b08261